### PR TITLE
Update cost.py to include claude-v1.3-100k

### DIFF
--- a/gptcli/cost.py
+++ b/gptcli/cost.py
@@ -77,6 +77,7 @@ PRICE_PER_TOKEN = {
     "claude-v1.0": CLAUDE_V1_PRICE_PER_TOKEN,
     "claude-v1.2": CLAUDE_V1_PRICE_PER_TOKEN,
     "claude-v1.3": CLAUDE_V1_PRICE_PER_TOKEN,
+    "claude-v1.3-100k": CLAUDE_V1_PRICE_PER_TOKEN,
     "claude-instant-v1": CLAUDE_INSTANT_V1_PRICE_PER_TOKEN,
     "claude-instant-v1-100k": CLAUDE_INSTANT_V1_PRICE_PER_TOKEN,
     "claude-instant-v1.0": CLAUDE_INSTANT_V1_PRICE_PER_TOKEN,


### PR DESCRIPTION
Fix the error caused by running `./gpt.py --model claude-v1.3-100k` :

```
KeyError: 'claude-v1.3-100k'
An uncaught exception occurred. Please report this issue on GitHub.
Traceback (most recent call last):
  File "gpt-cli/./gpt.py", line 233, in <module>
    main()
...
    PRICE_PER_TOKEN[model]["prompt"] * num_tokens_prompt
KeyError: 'claude-v1.3-100k'
```