### PR TITLE
Add pyproject.toml, allowing for pipx install from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,33 @@ Command-line interface for ChatGPT Claude and Bard.
 
 ## Installation
 
-At present, the simplest way is to clone the repository to your machine and then install the tool as described below.
+### `pip` or `pipx`
+
+At present, the simplest way is to use [`pipx`](https://pypa.github.io/pipx/) or `pip` to install from this github repository.
+
+```bash:
+pipx install https://github.com/kharvd/gpt-cli
+# OR
+pip install https://github.com/kharvd/gpt-cli
+```
+
+Add the OpenAI API key to your `.bashrc` file (in the root of your home folder).
+In this example we use nano, you can use any text editor.
+
+```
+nano ~/.bashrc
+export OPENAI_API_KEY=<your_key_here>
+```
+
+Run the tool
+
+```
+gpt
+```
+
+### Installation from Source
+
+You can clone the repository to your machine and then install the tool as described below.
 
 This install assumes a Linux/OSX machine with python and pip available.
 
@@ -39,19 +65,19 @@ export OPENAI_API_KEY=<your_key_here>
 Run the tool
 
 ```
-./gpt.py
+./gpt
 ```
 
 If you want to start the program from anywhere, you might want to create an alias in your `.bashrc`.
 
 ```
-alias gpt="/path/to/gpt-cli/gpt.py"
+alias gpt="/path/to/gpt-cli/gpt"
 ```
 
 Alternatively, you can create a symbolic link to the executable in a directory that is in your path, like in the following example.
 
 ```
-ln -s /path/to/gpt-cli/gpt.py /usr/bin/gpt
+ln -s /path/to/gpt-cli/gpt /usr/bin/gpt
 ```
 
 You can also use a `gpt.yml` file for configuration. See the [Configuration](README.md#Configuration) section below.
@@ -61,7 +87,7 @@ You can also use a `gpt.yml` file for configuration. See the [Configuration](REA
 Make sure to set the `OPENAI_API_KEY` environment variable to your OpenAI API key (or put it in the `~/.config/gpt-cli/gpt.yml` file as described below).
 
 ```
-usage: gpt.py [-h] [--no_markdown] [--model MODEL] [--temperature TEMPERATURE] [--top_p TOP_P]
+usage: gpt [-h] [--no_markdown] [--model MODEL] [--temperature TEMPERATURE] [--top_p TOP_P]
               [--log_file LOG_FILE] [--log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
               [--prompt PROMPT] [--execute EXECUTE] [--no_stream]
               [{dev,general,bash}]
@@ -116,7 +142,7 @@ The meaning of life is subjective and can be different for diverse human beings 
 The `dev` assistant is instructed to be an expert in software development and provide short responses.
 
 ```bash
-$ ./gpt.py dev
+$ ./gpt dev
 ```
 
 The `bash` assistant is instructed to be an expert in bash scripting and provide only bash commands. Use the `--execute` option to execute the commands. It works best with the `gpt-4` model.

--- a/gpt
+++ b/gpt
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+python -m gptcli "$@"

--- a/gptcli/__main__.py
+++ b/gptcli/__main__.py
@@ -48,7 +48,8 @@ sys.excepthook = exception_handler
 
 def parse_args(config: GptCliConfig):
     parser = argparse.ArgumentParser(
-        description="Run a chat session with ChatGPT. See https://github.com/kharvd/gpt-cli for more information."
+        prog="gpt",
+        description="Run a chat session with ChatGPT. See https://github.com/kharvd/gpt-cli for more information.",
     )
     parser.add_argument(
         "assistant_name",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gpt-cli"
+authors = [{ name = "Val Kharitonov" }]
+description = "Command-line interface for ChatGPT, Claude and Bard"
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = ["Programming Language :: Python :: 3"]
+dynamic = ["version", "dependencies"]
+
+[tool.setuptools]
+dynamic = {dependencies = {file = "requirements.txt"}}
+packages = {find = {}}
+
+[project.scripts]
+gpt = "gptcli.__main__:main"


### PR DESCRIPTION
This PR adds a `pyproject.toml` file to the project, which enables the project
to be installed via `pip` or `pipx`. This means users won't have to fiddle
around with cloning the repo and installing the dependencies manually.

In addition to adding `pyproject.toml`, this PR also:
- renames `gpt.py` to `gptcli/__main__.py`
- creates a new convenience executable shell script `gpt` at the top level of the project
- Adds an argument `prog="gpt"` to the `ArgumentParser` in `__main__.py`. This way running `gpt --help` will display the correct program name `gpt` instead of displaying `__main__`.

# Testing

To test this out using [`pipx`](https://pypa.github.io/pipx/) or pip, run the following commands to install from
the `to-upstream` branch on my fork of this repo.

```bash
# using pipx
$ pipx install git+https://github.com/jasha10/gpt-cli@to-upstream
$ gpt
Hi! I'm here to help. ...
```
