### PR TITLE
Require Python 3.9+ to match fixed upstream google-generativeai package

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+
+import sys
+MIN_PYTHON = (3, 9)
+if sys.version_info < MIN_PYTHON:
+    sys.exit("Python %s.%s or later is required.\n" % MIN_PYTHON)
+
 import os
 from typing import cast
 import openai
@@ -32,7 +38,6 @@ from gptcli.shell import execute, simple_response
 
 
 logger = logging.getLogger("gptcli")
-
 
 default_exception_handler = sys.excepthook
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anthropic==0.2.8
 black==23.1.0
-google-generativeai==0.1.0rc2
+google-generativeai==0.1.0
 llama-cpp-python==0.1.57
 openai==0.27.8
 prompt-toolkit==3.0.38


### PR DESCRIPTION
Upstream `google-generativeai@0.1.0` requires Python 3.9+. The older version we currently use (`0.1.0rc2` ) implicitly requires it anyway (see https://github.com/kharvd/gpt-cli/issues/29).

macOS Ventura's default `python3` version is `3.8.9` so this might introduce friction to many future adopters. I propose we unbreak this for now, and consider alternatives (ex. conditional loading) if we're worried about it.