### PR TITLE
Allow customing log filename with date and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ optional arguments:
                         temperature defined for the assistant.
   --top_p TOP_P         The top_p to use for the chat session. Overrides the default top_p defined
                         for the assistant.
-  --log_file LOG_FILE   The file to write logs to
+  --log_file LOG_FILE   The file to write logs to. Supports strftime format codes.
   --log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         The log level to use
   --prompt PROMPT, -p PROMPT

--- a/gpt.py
+++ b/gpt.py
@@ -11,6 +11,7 @@ import openai
 import argparse
 import sys
 import logging
+import datetime
 import google.generativeai as genai
 import gptcli.anthropic
 from gptcli.assistant import (
@@ -92,7 +93,7 @@ def parse_args(config: GptCliConfig):
         "--log_file",
         type=str,
         default=config.log_file,
-        help="The file to write logs to",
+        help="The file to write logs to. Supports strftime format codes.",
     )
     parser.add_argument(
         "--log_level",
@@ -150,8 +151,9 @@ def main():
     args = parse_args(config)
 
     if args.log_file is not None:
+        filename = datetime.datetime.now().strftime(args.log_file)
         logging.basicConfig(
-            filename=args.log_file,
+            filename=filename,
             level=args.log_level,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )


### PR DESCRIPTION
I find this useful myself, so I thought I'd make a PR.

This runs the logfile name through strftime, making it easy to make logs based on the current time + date. For example, I use:

`logs/gpt-cli/%Y-%m-%d_%H-%M-%S.log`

The only problem I see with this is it might break logging for people who used `%` as part of the filename (as anything starting `%` will get interpreted by strftime).