### PR TITLE
Add confirmation when clearing the conversation with Ctrl+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ optional arguments:
   --no_price            Disable price logging.
 ```
 
-Type `q` or Ctrl-D to exit, `c` or Ctrl-C to clear the conversation, `r` or Ctrl-R to re-generate the last response.
+Type `:q` or Ctrl-D to exit, `:c` or Ctrl-C to clear the conversation, `:r` or Ctrl-R to re-generate the last response.
 To enter multi-line mode, enter a backslash `\` followed by a new line. Exit the multi-line mode by pressing ESC and then Enter.
 
 You can override the model parameters using `--model`, `--temperature` and `--top_p` arguments at the end of your prompt. For example:

--- a/gptcli/cli.py
+++ b/gptcli/cli.py
@@ -23,10 +23,11 @@ from gptcli.session import (
 
 
 TERMINAL_WELCOME = """
-Hi! I'm here to help. Type `q` or Ctrl-D to exit, `c` or Ctrl-C to clear
-the conversation, `r` or Ctrl-R to re-generate the last response.
+Hi! I'm here to help. Type `:q` or Ctrl-D to exit, `:c` or Ctrl-C and Enter to clear
+the conversation, `:r` or Ctrl-R to re-generate the last response.
 To enter multi-line mode, enter a backslash `\\` followed by a new line.
 Exit the multi-line mode by pressing ESC and then Enter (Meta+Enter).
+Try `:?` for help.
 """
 
 
@@ -164,7 +165,7 @@ class CLIUserInputProvider(UserInputProvider):
         def _(event: KeyPressEvent):
             if len(event.current_buffer.text) == 0 and not multiline:
                 event.current_buffer.text = COMMAND_CLEAR[0]
-                event.current_buffer.validate_and_handle()
+                event.current_buffer.cursor_right(len(COMMAND_CLEAR[0]))
             else:
                 event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
 

--- a/gptcli/session.py
+++ b/gptcli/session.py
@@ -53,10 +53,18 @@ class InvalidArgumentError(Exception):
         self.message = message
 
 
-COMMAND_CLEAR = ("clear", "c")
-COMMAND_QUIT = ("quit", "q")
-COMMAND_RERUN = ("rerun", "r")
-ALL_COMMANDS = [*COMMAND_CLEAR, *COMMAND_QUIT, *COMMAND_RERUN]
+COMMAND_CLEAR = (":clear", ":c")
+COMMAND_QUIT = (":quit", ":q")
+COMMAND_RERUN = (":rerun", ":r")
+COMMAND_HELP = (":help", ":h", ":?")
+ALL_COMMANDS = [*COMMAND_CLEAR, *COMMAND_QUIT, *COMMAND_RERUN, *COMMAND_HELP]
+COMMANDS_HELP = """
+Commands:
+- `:clear` / `:c` / Ctrl+C - Clear the conversation.
+- `:quit` / `:q` / Ctrl+D - Quit the program.
+- `:rerun` / `:r` / Ctrl+R - Re-run the last message.
+- `:help` / `:h` / `:?` - Show this help message.
+"""
 
 
 class ChatSession:
@@ -140,6 +148,10 @@ class ChatSession:
         self.messages = self.messages[:-1]
         self.user_prompts = self.user_prompts[:-1]
 
+    def _print_help(self):
+        with self.listener.response_streamer() as stream:
+            stream.on_next_token(COMMANDS_HELP)
+
     def process_input(self, user_input: str, args: Dict[str, Any]):
         """
         Process the user's input and return whether the session should continue.
@@ -154,6 +166,9 @@ class ChatSession:
             return True
         elif user_input in COMMAND_RERUN:
             self._rerun()
+            return True
+        elif user_input in COMMAND_HELP:
+            self._print_help()
             return True
 
         self._add_user_message(user_input, args)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -51,7 +51,7 @@ def test_simple_input():
 
 def test_quit():
     _, _, session = setup_session()
-    should_continue = session.process_input("q", {})
+    should_continue = session.process_input(":q", {})
     assert not should_continue
 
 
@@ -79,7 +79,7 @@ def test_clear():
     assistant_mock.complete_chat.reset_mock()
     listener_mock.on_chat_message.reset_mock()
 
-    should_continue = session.process_input("c", {})
+    should_continue = session.process_input(":c", {})
     assert should_continue
 
     assistant_mock.init_messages.assert_called_once()
@@ -110,7 +110,7 @@ def test_rerun():
     assistant_mock.init_messages.reset_mock()
 
     # Re-run before any input shouldn't do anything
-    should_continue = session.process_input("r", {})
+    should_continue = session.process_input(":r", {})
     assert should_continue
 
     assistant_mock.init_messages.assert_not_called()
@@ -141,7 +141,7 @@ def test_rerun():
 
     assistant_mock.complete_chat.return_value = ["assistant_message_1"]
 
-    should_continue = session.process_input("r", {})
+    should_continue = session.process_input(":r", {})
     assert should_continue
 
     listener_mock.on_chat_rerun.assert_called_once_with(True)
@@ -185,7 +185,7 @@ def test_args():
 
     assistant_mock.complete_chat.return_value = [expected_response]
 
-    should_continue = session.process_input("r", {})
+    should_continue = session.process_input(":r", {})
     assert should_continue
 
     assistant_mock.complete_chat.assert_called_once_with(
@@ -213,7 +213,7 @@ def test_invalid_request_error():
     listener_mock.on_chat_message.reset_mock()
     listener_mock.on_error.reset_mock()
 
-    should_continue = session.process_input("r", {})
+    should_continue = session.process_input(":r", {})
     assert should_continue
 
     assistant_mock.complete_chat.assert_not_called()
@@ -248,7 +248,7 @@ def test_openai_error():
     assistant_mock.complete_chat.side_effect = None
     assistant_mock.complete_chat.return_value = ["assistant message"]
 
-    should_continue = session.process_input("r", {})
+    should_continue = session.process_input(":r", {})
     assert should_continue
 
     assistant_mock.complete_chat.assert_called_once_with(


### PR DESCRIPTION
Now instead of clearing automatically, `Ctrl+C` will only insert `:clear` in the terminal. Pressing Enter after that will clear the conversation.

Additionally, commands are now prefixed with a colon to minimize confusion