### PR TITLE
feat(fine tuned models) enable access to fine tuned OpenAI models whi…

### DIFF
--- a/gptcli/assistant.py
+++ b/gptcli/assistant.py
@@ -56,7 +56,7 @@ DEFAULT_ASSISTANTS: Dict[str, AssistantConfig] = {
 
 
 def get_completion_provider(model: str) -> CompletionProvider:
-    if model.startswith("gpt"):
+    if model.startswith("gpt") or model.startswith("ft:gpt"):
         return OpenAICompletionProvider()
     elif model.startswith("claude"):
         return AnthropicCompletionProvider()


### PR DESCRIPTION
Allow the use of fine-tuned OpenAI gpt 3.5 Turbo models which start with ft:gpt, this is especially useful when trying to compare the stock models against fine-tuned models quickly.