### PR TITLE
custom openai base url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ $ gpt pirate
 Ahoy, matey! What be bringing ye to these here waters? Be it treasure or adventure ye seek, we be sailing the high seas together. Ready yer map and compass, for we have a long voyage ahead!
 ```
 
+### Customize OpenAI API URL
+If you are using other models compatible with the OpenAI Python SDK, you can configure them by modifying the `openai_base_url` setting in the config file or using the `OPENAI_BASE_URL` environment variable .  
+
+Example:
+```
+openai_base_url: https://your-custom-api-url.com/v1
+```
+
 ## Other chat bots
 
 ### Anthropic Claude

--- a/gptcli/config.py
+++ b/gptcli/config.py
@@ -20,6 +20,7 @@ class GptCliConfig:
     show_price: bool = True
     api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
     openai_api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
+    openai_base_url: Optional[str] = os.environ.get("OPENAI_BASE_URL")
     anthropic_api_key: Optional[str] = os.environ.get("ANTHROPIC_API_KEY")
     google_api_key: Optional[str] = os.environ.get("GOOGLE_API_KEY")
     log_file: Optional[str] = None

--- a/gptcli/gpt.py
+++ b/gptcli/gpt.py
@@ -168,6 +168,9 @@ def main():
         # Disable overly verbose logging for markdown_it
         logging.getLogger("markdown_it").setLevel(logging.INFO)
 
+    if config.openai_base_url:
+        openai.base_url = config.openai_base_url
+
     if config.api_key:
         openai.api_key = config.api_key
     elif config.openai_api_key:

--- a/gptcli/openai.py
+++ b/gptcli/openai.py
@@ -10,7 +10,7 @@ from gptcli.completion import CompletionProvider, Message
 
 class OpenAICompletionProvider(CompletionProvider):
     def __init__(self):
-        self.client = OpenAI(api_key=openai.api_key)
+        self.client = OpenAI(api_key=openai.api_key, base_url=openai.base_url)
 
     def complete(
         self, messages: List[Message], args: dict, stream: bool = False


### PR DESCRIPTION
I am using an LLM model compatible with OpenAI, and it would be great if the user could use a customized URL.

Also close #42 