### PR TITLE
Escapable blocks of text

### DIFF
--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -16,3 +16,23 @@ def test_parse_args():
         "this is a prompt",
         {"bar": "1.0", "baz": "2.0"},
     )
+    assert parse_args("```this is a prompt --bar=1.0 --baz=2.0```") == (
+        "this is a prompt --bar=1.0 --baz=2.0",
+        {},
+    )
+    assert parse_args("this is a prompt --bar=1.0 ```--baz=2.0```") == (
+        "this is a prompt  --baz=2.0",
+        {"bar": "1.0"},
+    )
+    assert parse_args("this is a prompt ```--bar=1.0``` --baz=2.0") == (
+        "this is a prompt --bar=1.0",
+        {"baz": "2.0"},
+    )
+    assert parse_args('"""this is a prompt --bar=3.0 --baz=4.0"""') == (
+        "this is a prompt --bar=3.0 --baz=4.0",
+        {},
+    )
+    assert parse_args('this is a prompt --bar=1.0 """--baz=2.0"""') == (
+        "this is a prompt  --baz=2.0",
+        {"bar": "1.0"},
+    )

--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -25,29 +25,40 @@ def test_parse_args():
 def test_parse_with_escape_blocks():
     test_cases = [
         (
+            # escaped text at end of prompt
             "this is a prompt --bar=1.0 {start}--baz=2.0{end}",
             "this is a prompt  {start}--baz=2.0{end}",
             {"bar": "1.0"},
         ),
         (
+            # escaped text in middle of prompt with equal assignment
             "this is a prompt {start}--bar=1.0{end} --baz=2.0",
             "this is a prompt {start}--bar=1.0{end}",
             {"baz": "2.0"},
         ),
         (
+            # escaped text in middle of prompt with space assignment
             "this is a prompt {start}--bar 1.0{end} --baz 2.0",
             "this is a prompt {start}--bar 1.0{end}",
             {"baz": "2.0"},
         ),
         (
+            # escaped text in multiple escape sequences
             'this is a prompt --bar=1.0 {start}my first context block{end} and then ```my second context block``` --baz=2.0',
             'this is a prompt  {start}my first context block{end} and then ```my second context block```',
             {'bar': '1.0', 'baz': '2.0'},
         ),
         (
+            # entire prompt is escaped
             "{start}this is a prompt --bar=1.0 --baz=2.0{end}",
             "{start}this is a prompt --bar=1.0 --baz=2.0{end}",
-            {}
+            {},
+        ),
+        (
+            # multi-line escaped text
+            "this is a prompt \n--bar=1.0 \n--baz=2.0 \n {start}another line \nmy final line{end}",
+            "this is a prompt \n \n \n {start}another line \nmy final line{end}",
+            {'bar': '1.0', 'baz': '2.0'},
         )
     ]
 

--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -44,15 +44,16 @@ def test_parse_with_escape_blocks():
             'this is a prompt  {start}my first context block{end} and then ```my second context block```',
             {'bar': '1.0', 'baz': '2.0'},
         ),
+        (
+            "{start}this is a prompt --bar=1.0 --baz=2.0{end}",
+            "{start}this is a prompt --bar=1.0 --baz=2.0{end}",
+            {}
+        )
     ]
 
     delimiters = ["```", '"""', "`"]
 
     for start, end in [(d, d) for d in delimiters]:
-        assert parse_args(f"{start}this is a prompt --bar=1.0 --baz=2.0{end}") == (
-            f"{start}this is a prompt --bar=1.0 --baz=2.0{end}",
-            {},
-        )
         for prompt, expected_prompt, expected_args in test_cases:
             formatted_prompt = prompt.format(start=start, end=end)
             formatted_expected_prompt = expected_prompt.format(start=start, end=end)

--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -16,23 +16,38 @@ def test_parse_args():
         "this is a prompt",
         {"bar": "1.0", "baz": "2.0"},
     )
-    assert parse_args("```this is a prompt --bar=1.0 --baz=2.0```") == (
-        "this is a prompt --bar=1.0 --baz=2.0",
-        {},
-    )
-    assert parse_args("this is a prompt --bar=1.0 ```--baz=2.0```") == (
-        "this is a prompt  --baz=2.0",
-        {"bar": "1.0"},
-    )
-    assert parse_args("this is a prompt ```--bar=1.0``` --baz=2.0") == (
-        "this is a prompt --bar=1.0",
-        {"baz": "2.0"},
-    )
-    assert parse_args('"""this is a prompt --bar=3.0 --baz=4.0"""') == (
-        "this is a prompt --bar=3.0 --baz=4.0",
-        {},
-    )
-    assert parse_args('this is a prompt --bar=1.0 """--baz=2.0"""') == (
-        "this is a prompt  --baz=2.0",
-        {"bar": "1.0"},
-    )
+
+
+def test_parse_with_escape_blocks():
+    test_cases = [
+        (
+            "this is a prompt --bar=1.0 {start}--baz=2.0{end}",
+            "this is a prompt  {start}--baz=2.0{end}",
+            {"bar": "1.0"},
+        ),
+        (
+            "this is a prompt {start}--bar=1.0{end} --baz=2.0",
+            "this is a prompt {start}--bar=1.0{end}",
+            {"baz": "2.0"},
+        ),
+        (
+            'this is a prompt --bar=1.0 {start}my first context block{end} and then ```my second context block``` --baz=2.0',
+            'this is a prompt  {start}my first context block{end} and then ```my second context block```',
+            {'bar': '1.0', 'baz': '2.0'},
+        ),
+    ]
+
+    delimiters = ["```", '"""', "`"]
+
+    for start, end in [(d, d) for d in delimiters]:
+        assert parse_args(f"{start}this is a prompt --bar=1.0 --baz=2.0{end}") == (
+            f"{start}this is a prompt --bar=1.0 --baz=2.0{end}",
+            {},
+        )
+        for prompt, expected_prompt, expected_args in test_cases:
+            formatted_prompt = prompt.format(start=start, end=end)
+            formatted_expected_prompt = expected_prompt.format(start=start, end=end)
+            assert parse_args(formatted_prompt) == (
+                formatted_expected_prompt,
+                expected_args,
+            )

--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -56,10 +56,11 @@ def test_parse_with_escape_blocks():
         ),
         (
             # multi-line escaped text
-            "this is a prompt \n--bar=1.0 \n--baz=2.0 \n {start}another line \nmy final line{end}",
-            "this is a prompt \n \n \n {start}another line \nmy final line{end}",
+            "this is a prompt \n--bar=1.0 --baz=2.0\n{start}--foo=3.0 \n another line \nmy final line{end}",
+            "this is a prompt \n \n{start}--foo=3.0 \n another line \nmy final line{end}",
             {'bar': '1.0', 'baz': '2.0'},
         )
+
     ]
 
     delimiters = ["```", '"""', "`"]

--- a/tests/test_term_utils.py
+++ b/tests/test_term_utils.py
@@ -16,6 +16,10 @@ def test_parse_args():
         "this is a prompt",
         {"bar": "1.0", "baz": "2.0"},
     )
+    assert parse_args("this is a prompt --bar 1.0") == (
+        "this is a prompt",
+        {"bar": "1.0"},
+    )
 
 
 def test_parse_with_escape_blocks():
@@ -28,6 +32,11 @@ def test_parse_with_escape_blocks():
         (
             "this is a prompt {start}--bar=1.0{end} --baz=2.0",
             "this is a prompt {start}--bar=1.0{end}",
+            {"baz": "2.0"},
+        ),
+        (
+            "this is a prompt {start}--bar 1.0{end} --baz 2.0",
+            "this is a prompt {start}--bar 1.0{end}",
             {"baz": "2.0"},
         ),
         (


### PR DESCRIPTION
allow escapable blocks of text when wrapped in triple backticks or quotes.  Fixes #52