### PR TITLE
Updated chat sessions to be able to take the no_stream option

### DIFF
--- a/gptcli/gpt.py
+++ b/gptcli/gpt.py
@@ -230,7 +230,7 @@ def run_non_interactive(args, assistant):
 
 
 class CLIChatSession(ChatSession):
-    def __init__(self, assistant: Assistant, markdown: bool, show_price: bool):
+    def __init__(self, assistant: Assistant, markdown: bool, show_price: bool, stream: bool):
         listeners = [
             CLIChatListener(markdown),
             LoggingChatListener(),
@@ -240,13 +240,14 @@ class CLIChatSession(ChatSession):
             listeners.append(PriceChatListener(assistant))
 
         listener = CompositeChatListener(listeners)
+        self.stream = stream
         super().__init__(assistant, listener)
 
 
 def run_interactive(args, assistant):
     logger.info("Starting a new chat session. Assistant config: %s", assistant.config)
     session = CLIChatSession(
-        assistant=assistant, markdown=args.markdown, show_price=args.show_price
+        assistant=assistant, markdown=args.markdown, show_price=args.show_price, stream=not args.no_stream
     )
     history_filename = os.path.expanduser("~/.config/gpt-cli/history")
     os.makedirs(os.path.dirname(history_filename), exist_ok=True)

--- a/gptcli/gpt.py
+++ b/gptcli/gpt.py
@@ -240,8 +240,7 @@ class CLIChatSession(ChatSession):
             listeners.append(PriceChatListener(assistant))
 
         listener = CompositeChatListener(listeners)
-        self.stream = stream
-        super().__init__(assistant, listener)
+        super().__init__(assistant, listener, stream)
 
 
 def run_interactive(args, assistant):

--- a/gptcli/session.py
+++ b/gptcli/session.py
@@ -112,7 +112,7 @@ class ChatSession:
         usage: Optional[UsageEvent] = None
         try:
             completion_iter = self.assistant.complete_chat(
-                self.messages, override_params=overrides
+                self.messages, override_params=overrides, stream=self.stream
             )
 
             with self.listener.response_streamer() as stream:

--- a/gptcli/session.py
+++ b/gptcli/session.py
@@ -81,11 +81,13 @@ class ChatSession:
         self,
         assistant: Assistant,
         listener: ChatListener,
+        stream: bool = True,
     ):
         self.assistant = assistant
         self.messages: List[Message] = assistant.init_messages()
         self.user_prompts: List[Tuple[Message, ModelOverrides]] = []
         self.listener = listener
+        self.stream = stream
 
     def _clear(self):
         self.messages = self.assistant.init_messages()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,7 +40,7 @@ def test_simple_input():
     assistant_message = {"role": "assistant", "content": expected_response}
 
     assistant_mock.complete_chat.assert_called_once_with(
-        [system_message, user_message], override_params={}
+        [system_message, user_message], override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [mock.call(user_message), mock.call(assistant_message)]
@@ -66,7 +66,7 @@ def test_clear():
 
     assistant_mock.complete_chat.assert_called_once_with(
         [system_message, {"role": "user", "content": "user_message"}],
-        override_params={},
+        override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [
@@ -93,7 +93,7 @@ def test_clear():
 
     assistant_mock.complete_chat.assert_called_once_with(
         [system_message, {"role": "user", "content": "user_message_1"}],
-        override_params={},
+        override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [
@@ -128,7 +128,7 @@ def test_rerun():
 
     assistant_mock.complete_chat.assert_called_once_with(
         [system_message, {"role": "user", "content": "user_message"}],
-        override_params={},
+        override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [
@@ -150,7 +150,7 @@ def test_rerun():
 
     assistant_mock.complete_chat.assert_called_once_with(
         [system_message, {"role": "user", "content": "user_message"}],
-        override_params={},
+        override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [
@@ -175,7 +175,7 @@ def test_args():
     assistant_message = {"role": "assistant", "content": expected_response}
 
     assistant_mock.complete_chat.assert_called_once_with(
-        [system_message, user_message], override_params={"arg1": "value1"}
+        [system_message, user_message], override_params={"arg1": "value1"}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [mock.call(user_message), mock.call(assistant_message)]
@@ -191,7 +191,7 @@ def test_args():
     assert should_continue
 
     assistant_mock.complete_chat.assert_called_once_with(
-        [system_message, user_message], override_params={"arg1": "value1"}
+        [system_message, user_message], override_params={"arg1": "value1"}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls([mock.call(assistant_message)])
 
@@ -250,7 +250,7 @@ def test_openai_error():
     assert should_continue
 
     assistant_mock.complete_chat.assert_called_once_with(
-        [system_message, user_message], override_params={}
+        [system_message, user_message], override_params={}, stream=True,
     )
     listener_mock.on_chat_message.assert_has_calls(
         [


### PR DESCRIPTION
Following #89, in order to run o1 models you need to supply the options:
```bash
gpt --no_stream --temperature=1 --model=o1-preview
```
as o1 is not built for more than one temperature and cannot stream.

Whilst `--no_stream` works for `--prompt` and `--execute`, it does not work for chat mode. This PR implements this by adding it as an attribute read from the command line arguments to `CLIChatSession`