### PR TITLE
Implement new flag to disable the printing of the welcome message

### DIFF
--- a/gptcli/cli.py
+++ b/gptcli/cli.py
@@ -78,13 +78,15 @@ class CLIResponseStreamer(ResponseStreamer):
 
 
 class CLIChatListener(ChatListener):
-    def __init__(self, markdown: bool):
+    def __init__(self, markdown: bool, print_welcome: bool):
         self.markdown = markdown
+        self.print_welcome = print_welcome
         self.console = Console()
 
     def on_chat_start(self):
         console = Console(width=80)
-        console.print(Markdown(TERMINAL_WELCOME))
+        if self.print_welcome:
+            console.print(Markdown(TERMINAL_WELCOME))
 
     def on_chat_clear(self):
         self.console.print("[bold]Cleared the conversation.[/bold]")

--- a/gptcli/config.py
+++ b/gptcli/config.py
@@ -18,6 +18,7 @@ class GptCliConfig:
     default_assistant: str = "general"
     markdown: bool = True
     show_price: bool = True
+    print_welcome: bool = True
     api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
     openai_api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
     openai_base_url: Optional[str] = os.environ.get("OPENAI_BASE_URL")

--- a/gptcli/gpt.py
+++ b/gptcli/gpt.py
@@ -140,6 +140,13 @@ response in a script. Ignored when the --prompt option is not specified.",
         default=config.show_price,
     )
     parser.add_argument(
+        "--no_welcome",
+        action="store_false",
+        dest="print_welcome",
+        help="Deactivate the welcome message being printed to the top of the terminal.",
+        default=config.print_welcome,
+    )
+    parser.add_argument(
         "--version",
         "-v",
         action="version",
@@ -230,9 +237,9 @@ def run_non_interactive(args, assistant):
 
 
 class CLIChatSession(ChatSession):
-    def __init__(self, assistant: Assistant, markdown: bool, show_price: bool):
+    def __init__(self, assistant: Assistant, markdown: bool, show_price: bool, print_welcome: bool):
         listeners = [
-            CLIChatListener(markdown),
+            CLIChatListener(markdown, print_welcome),
             LoggingChatListener(),
         ]
 
@@ -246,7 +253,7 @@ class CLIChatSession(ChatSession):
 def run_interactive(args, assistant):
     logger.info("Starting a new chat session. Assistant config: %s", assistant.config)
     session = CLIChatSession(
-        assistant=assistant, markdown=args.markdown, show_price=args.show_price
+        assistant=assistant, markdown=args.markdown, show_price=args.show_price, print_welcome=args.print_welcome
     )
     history_filename = os.path.expanduser("~/.config/gpt-cli/history")
     os.makedirs(os.path.dirname(history_filename), exist_ok=True)


### PR DESCRIPTION
I have implemented the feature to disable the printing of the welcome message with the hints to the terminal every time the tool is run.

This pull request aims to resolve #92 which I opened as a feature request.

Please let me know whether my contributions are welcome, as I like the project and have ideas to enhance it.