### PR TITLE
Implement a :back command to go back to a specific message pair.

### DIFF
--- a/gptcli/cli.py
+++ b/gptcli/cli.py
@@ -24,6 +24,7 @@ from gptcli.session import (
 TERMINAL_WELCOME = """
 Hi! I'm here to help. Type `:q` or Ctrl-D to exit, `:c` or Ctrl-C and Enter to clear
 the conversation, `:r` or Ctrl-R to re-generate the last response.
+Type `:b X` where X is a message pair number to go back to that message pair.
 To enter multi-line mode, enter a backslash `\\` followed by a new line.
 Exit the multi-line mode by pressing ESC and then Enter (Meta+Enter).
 Try `:?` for help.
@@ -100,6 +101,9 @@ class CLIChatListener(ChatListener):
             self.console.print("[bold]Re-running the last message.[/bold]")
         else:
             self.console.print("[bold]Nothing to re-run.[/bold]")
+
+    def on_chat_back(self, x: int):
+        self.console.print(f"[bold]Going back to message pair {x}.[/bold]")
 
     def on_error(self, e: Exception):
         if isinstance(e, BadRequestError):

--- a/gptcli/composite.py
+++ b/gptcli/composite.py
@@ -39,6 +39,10 @@ class CompositeChatListener(ChatListener):
         for listener in self.listeners:
             listener.on_chat_rerun(success)
 
+    def on_chat_back(self, x: int):
+        for listener in self.listeners:
+            listener.on_chat_back(x)
+
     def on_error(self, e: Exception):
         for listener in self.listeners:
             listener.on_error(e)

--- a/gptcli/cost.py
+++ b/gptcli/cost.py
@@ -30,6 +30,7 @@ class PriceChatListener(ChatListener):
         model = self.assistant._param("model")
         num_tokens = usage.total_tokens
         cost = usage.cost
+        message_idx = len(messages) // 2
 
         if cost is None:
             self.logger.error(f"Cannot get cost information for model {model}")
@@ -40,7 +41,7 @@ class PriceChatListener(ChatListener):
         self.logger.info(f"Message price (model: {model}): ${cost:.3f}")
         self.logger.info(f"Current spend: ${self.current_spend:.3f}")
         self.console.print(
-            f"Tokens: {num_tokens} | Price: ${cost:.3f} | Total: ${self.current_spend:.3f}",
+            f"Message pair #: {message_idx} | Tokens: {num_tokens} | Price: ${cost:.3f} | Total: ${self.current_spend:.3f}",
             justify="right",
             style="dim",
         )

--- a/gptcli/logging_utils.py
+++ b/gptcli/logging_utils.py
@@ -17,6 +17,9 @@ class LoggingChatListener(ChatListener):
         if success:
             self.logger.info("Re-generating the last message.")
 
+    def on_chat_back(self, x: int):
+        self.logger.info(f"Going back to message pair {x}.")
+
     def on_error(self, e: Exception):
         self.logger.exception(e)
 

--- a/gptcli/session.py
+++ b/gptcli/session.py
@@ -31,6 +31,9 @@ class ChatListener:
     def on_chat_rerun(self, success: bool):
         pass
 
+    def on_chat_back(self, x: int):
+        pass
+
     def on_error(self, error: Exception):
         pass
 
@@ -152,6 +155,7 @@ class ChatSession:
         Go back to user-assistant message pair x in the conversation. Following messages will be discarded.
         """
         self._rollback_user_message(x)
+        self.listener.on_chat_back(x)
 
     def _rollback_user_message(self, x: int = None):
         if x is None:


### PR DESCRIPTION
- Implements functionality to go back to a specific message.
- The footer, which currently includes the conversation cost and the number of tokens, will now display the number (identifier) of each message-pair.
- A message pair is a user's message followed by the model's response.
- Typing ':b' or ':back' will undo the last message-pair, including the user's message unlike ':r' which keeps it.
- Typing ':b X' or ':back X' will go back in the conversation state to message-pair X and confirm it via displaying a string in the console.
- Going back to X means that X is still part of the conversation with later messages removed.