### PR TITLE
Added o3 and updated openai pricing

### DIFF
--- a/gptcli/assistant.py
+++ b/gptcli/assistant.py
@@ -79,6 +79,7 @@ def get_completion_provider(
         or model.startswith("oai-compat:")
         or model.startswith("chatgpt")
         or model.startswith("o1")
+        or model.startswith("o3")
     ):
         return OpenAICompletionProvider(
             openai_base_url_override, openai_api_key_override

--- a/gptcli/providers/openai.py
+++ b/gptcli/providers/openai.py
@@ -87,19 +87,60 @@ class OpenAICompletionProvider(CompletionProvider):
             raise CompletionError(e.message) from e
 
 
-GPT_3_5_TURBO_PRICE_PER_TOKEN: Pricing = {
+GPT_3_5_TURBO_0125_PRICE_PER_TOKEN: Pricing = {
     "prompt": 0.50 / 1_000_000,
     "response": 1.50 / 1_000_000,
 }
 
-GPT_3_5_TURBO_16K_PRICE_PER_TOKEN: Pricing = {
-    "prompt": 0.003 / 1000,
-    "response": 0.004 / 1000,
+GPT_3_5_TURBO_INSTRUCT_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.50 / 1_000_000,
+    "response": 2.00 / 1_000_000,
 }
+
+GPT_3_5_TURBO_1106_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.00 / 1_000_000,
+    "response": 2.00 / 1_000_000,
+}
+
+GPT_3_5_TURBO_0613_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.50 / 1_000_000,
+    "response": 2.00 / 1_000_000,
+}
+
+GPT_3_5_TURBO_16K_0613_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 3.00 / 1_000_000,
+    "response": 4.00 / 1_000_000,
+}
+
+GPT_3_5_TURBO_0301_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.50 / 1_000_000,
+    "response": 2.00 / 1_000_000,
+}
+
 
 GPT_4_PRICE_PER_TOKEN: Pricing = {
     "prompt": 30.0 / 1_000_000,
     "response": 60.0 / 1_000_000,
+}
+
+GPT_4_32K_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 60.0 / 1_000_000,
+    "response": 120.0 / 1_000_000,
+}
+
+GPT_4_0125_PREVIEW_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 10.0 / 1_000_000,
+    "response": 30.0 / 1_000_000,
+}
+
+GPT_4_1106_PREVIEW_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 10.0 / 1_000_000,
+    "response": 30.0 / 1_000_000,
+}
+
+GPT_4_VISION_PREVIEW_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 10.0 / 1_000_000,
+    "response": 30.0 / 1_000_000,
 }
 
 GPT_4_TURBO_PRICE_PER_TOKEN: Pricing = {
@@ -107,10 +148,11 @@ GPT_4_TURBO_PRICE_PER_TOKEN: Pricing = {
     "response": 30.0 / 1_000_000,
 }
 
-GPT_4_32K_PRICE_PER_TOKEN: Pricing = {
-    "prompt": 60.0 / 1_000_000,
-    "response": 120.0 / 1_000_000,
+GPT_4_TURBO_2024_04_09_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 10.0 / 1_000_000,
+    "response": 30.0 / 1_000_000,
 }
+
 
 GPT_4_O_2024_05_13_PRICE_PER_TOKEN: Pricing = {
     "prompt": 5.0 / 1_000_000,
@@ -122,9 +164,59 @@ GPT_4_O_2024_08_06_PRICE_PER_TOKEN: Pricing = {
     "response": 10.0 / 1_000_000,
 }
 
+GPT_4_O_2024_11_20_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.50 / 1_000_000,
+    "response": 10.0 / 1_000_000,
+}
+
+GPT_4_O_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.50 / 1_000_000,
+    "response": 10.0 / 1_000_000,
+}
+
+GPT_4_O_AUDIO_PREVIEW_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.50 / 1_000_000,
+    "response": 10.0 / 1_000_000,
+}
+GPT_4_O_AUDIO_PREVIEW_2024_10_01_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.50 / 1_000_000,
+    "response": 10.0 / 1_000_000,
+}
+
+GPT_4_O_AUDIO_PREVIEW_2024_12_17_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.50 / 1_000_000,
+    "response": 10.0 / 1_000_000,
+}
+
+
 GPT_4_O_MINI_PRICE_PER_TOKEN: Pricing = {
     "prompt": 0.150 / 1_000_000,
     "response": 0.600 / 1_000_000,
+}
+
+GPT_4_O_MINI_2024_07_18_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 0.150 / 1_000_000,
+    "response": 0.600 / 1_000_000,
+}
+GPT_4_O_MINI_AUDIO_PREVIEW_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 0.150 / 1_000_000,
+    "response": 0.600 / 1_000_000,
+}
+GPT_4_O_MINI_AUDIO_PREVIEW_2024_12_17_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 0.150 / 1_000_000,
+    "response": 0.600 / 1_000_000,
+}
+
+
+
+O_1_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 15.0 / 1_000_000,
+    "response": 60.0 / 1_000_000,
+}
+
+O_1_2024_12_17_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 15.0 / 1_000_000,
+    "response": 60.0 / 1_000_000,
 }
 
 O_1_PREVIEW_PRICE_PER_TOKEN: Pricing = {
@@ -132,32 +224,117 @@ O_1_PREVIEW_PRICE_PER_TOKEN: Pricing = {
     "response": 60.0 / 1_000_000,
 }
 
-O_1_MINI_PRICE_PER_TOKEN: Pricing = {
-    "prompt": 3.0 / 1_000_000,
-    "response": 12.0 / 1_000_000,
+O_1_PREVIEW_2024_09_12_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 15.0 / 1_000_000,
+    "response": 60.0 / 1_000_000,
 }
 
 
+
+O_3_MINI_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.10 / 1_000_000,
+    "response": 4.40 / 1_000_000,
+}
+
+O_3_MINI_2025_01_31_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.10 / 1_000_000,
+    "response": 4.40 / 1_000_000,
+}
+
+O_1_MINI_2024_09_12_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 1.10 / 1_000_000,
+    "response": 4.40 / 1_000_000,
+}
+
+CHATGPT_4O_LATEST_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 5.00 / 1_000_000,
+    "response": 15.00 / 1_000_000,
+}
+
+
+DAVINCI_002_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 2.00 / 1_000_000,
+    "response": 2.00 / 1_000_000,
+}
+
+BABBAGE_002_PRICE_PER_TOKEN: Pricing = {
+    "prompt": 0.40 / 1_000_000,
+    "response": 0.40 / 1_000_000,
+}
+
+
+
 def gpt_pricing(model: str) -> Optional[Pricing]:
-    if model.startswith("gpt-3.5-turbo-16k"):
-        return GPT_3_5_TURBO_16K_PRICE_PER_TOKEN
-    elif model.startswith("gpt-3.5-turbo"):
-        return GPT_3_5_TURBO_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4-32k"):
-        return GPT_4_32K_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4o-mini"):
-        return GPT_4_O_MINI_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4o-2024-05-13") or model.startswith("chatgpt-4o-latest"):
-        return GPT_4_O_2024_05_13_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4o"):
-        return GPT_4_O_2024_08_06_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4-turbo") or re.match(r"gpt-4-\d\d\d\d-preview", model):
-        return GPT_4_TURBO_PRICE_PER_TOKEN
-    elif model.startswith("gpt-4"):
+    if model == "davinci-002":
+        return DAVINCI_002_PRICE_PER_TOKEN
+    elif model == "babbage-002":
+        return BABBAGE_002_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-0125":
+        return GPT_3_5_TURBO_0125_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-instruct":
+        return GPT_3_5_TURBO_INSTRUCT_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-1106":
+        return GPT_3_5_TURBO_1106_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-0613":
+        return GPT_3_5_TURBO_0613_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-16k-0613":
+        return GPT_3_5_TURBO_16K_0613_PRICE_PER_TOKEN
+    elif model == "gpt-3.5-turbo-0301":
+        return GPT_3_5_TURBO_0301_PRICE_PER_TOKEN
+
+    elif model == "gpt-4":
         return GPT_4_PRICE_PER_TOKEN
-    elif model.startswith("o1-preview"):
+    elif model == "gpt-4-32k":
+        return GPT_4_32K_PRICE_PER_TOKEN
+    elif model == "gpt-4-0125-preview":
+        return GPT_4_0125_PREVIEW_PRICE_PER_TOKEN
+    elif model == "gpt-4-1106-preview":
+        return GPT_4_1106_PREVIEW_PRICE_PER_TOKEN
+    elif model == "gpt-4-vision-preview":
+        return GPT_4_VISION_PREVIEW_PRICE_PER_TOKEN
+    elif model == "gpt-4-turbo":
+        return GPT_4_TURBO_PRICE_PER_TOKEN
+    elif model == "gpt-4-turbo-2024-04-09":
+        return GPT_4_TURBO_2024_04_09_PRICE_PER_TOKEN
+
+    elif model == "gpt-4o-2024-05-13":
+        return GPT_4_O_2024_05_13_PRICE_PER_TOKEN
+    elif model == "gpt-4o-2024-08-06":
+        return GPT_4_O_2024_08_06_PRICE_PER_TOKEN
+    elif model == "gpt-4o-2024-11-20":
+        return GPT_4_O_2024_11_20_PRICE_PER_TOKEN
+    elif model == "gpt-4o":
+        return GPT_4_O_PRICE_PER_TOKEN
+    elif model == "gpt-4o-audio-preview":
+        return GPT_4_O_AUDIO_PREVIEW_PRICE_PER_TOKEN
+    elif model == "gpt-4o-audio-preview-2024-10-01":
+        return GPT_4_O_AUDIO_PREVIEW_2024_10_01_PRICE_PER_TOKEN
+    elif model == "gpt-4o-audio-preview-2024-12-17":
+        return GPT_4_O_AUDIO_PREVIEW_2024_12_17_PRICE_PER_TOKEN
+    elif model == "gpt-4o-mini":
+        return GPT_4_O_MINI_PRICE_PER_TOKEN
+    elif model == "gpt-4o-mini-2024-07-18":
+        return GPT_4_O_MINI_2024_07_18_PRICE_PER_TOKEN
+    elif model == "gpt-4o-mini-audio-preview":
+        return GPT_4_O_MINI_AUDIO_PREVIEW_PRICE_PER_TOKEN
+    elif model == "gpt-4o-mini-audio-preview-2024-12-17":
+        return GPT_4_O_MINI_AUDIO_PREVIEW_2024_12_17_PRICE_PER_TOKEN
+
+    elif model == "o1":
+        return O_1_PRICE_PER_TOKEN
+    elif model == "o1-2024-12-17":
+        return O_1_2024_12_17_PRICE_PER_TOKEN
+    elif model == "o1-preview":
         return O_1_PREVIEW_PRICE_PER_TOKEN
-    elif model.startswith("o1-mini"):
-        return O_1_MINI_PRICE_PER_TOKEN
+    elif model == "o1-preview-2024-09-12":
+        return O_1_PREVIEW_2024_09_12_PRICE_PER_TOKEN
+    elif model == "o3-mini":
+        return O_3_MINI_PRICE_PER_TOKEN
+    elif model == "03-mini-2025-01-31":
+        return O_3_MINI_2025_01_31_PRICE_PER_TOKEN
+    elif model == "o1-mini-2024-09-12":
+        return O_1_MINI_2024_09_12_PRICE_PER_TOKEN
+    elif model == "chatgpt-4o-latest":
+        return CHATGPT_4O_LATEST_PRICE_PER_TOKEN
     else:
         return None


### PR DESCRIPTION
Title: feat: Add new pricing constants and support for o3 model

Summary:
This PR expands our support for OpenAI models by introducing additional pricing constants for several GPT-3.5, GPT-4, and related models, while also adding detection for the "o3" model type in the assistant. These changes ensure that our pricing logic reflects the latest API offerings and model variants.

Changes:
• In gptcli/assistant.py:
  - Updated the get_completion_provider() function to also return OpenAICompletionProvider when the model name starts with "o3". This extends our support for the new o3 variant.

• In gptcli/providers/openai.py:
  - Renamed and updated pricing constants for GPT-3.5 models (e.g., renamed GPT_3_5_TURBO_PRICE_PER_TOKEN to GPT_3_5_TURBO_0125_PRICE_PER_TOKEN and added constants for instruct, 1106, 0613, 16K_0613, 0301).
  - Added several new pricing dictionaries for GPT-4 models including preview, turbo, and vision variants, as well as additional pricing for GPT-4 O models (with various release dates) and GPT-4 O mini/audio editions.
  - Added constants for O_1 and O_3 series models, and also introduced new constants for Davinci and Babbage variants.
  - Refactored the gpt_pricing() function to use explicit equality checks for model names instead of prefix matching in many cases so that pricing retrieval is more precise and maintainable.

Rationale:
• Ensures support for the latest and upcoming OpenAI models, reflecting current pricing structures.
• Improves clarity and maintainability by having explicit mappings for each model variant.
• Future-proofs our codebase against potential changes in model naming conventions and pricing updates.

Testing:
• Verified that gpt_pricing() returns the appropriate pricing dictionary for each supported model.
• Confirmed that the new "o3" prefix correctly instantiates an OpenAICompletionProvider in the assistant.

Please review the changes and let me know if any adjustments are needed.


For reference, here is the prompt I used to update the pricing:
```markdown
Here is the openai pricing as copied from the openai website on 2025-02-01:

```text
GPT-4o
GPT-4o is our most advanced multimodal model that’s faster and cheaper than GPT-4 Turbo with stronger vision capabilities. The model has 128K context and an October 2023 knowledge cutoff.

Learn about GPT-4o(opens in a new window)
Model
Pricing
Pricing with Batch API*
gpt-4o
$2.50 / 1M input tokens
$1.25 / 1M input tokens
$1.25 / 1M cached** input tokens
$10.00 / 1M output tokens
$5.00 / 1M output tokens
gpt-4o-2024-11-20
$2.50 / 1M input tokens
$1.25 / 1M input tokens
$1.25 / 1M cached** input tokens
$10.00 / 1M output tokens
$5.00 / 1M output tokens
gpt-4o-2024-08-06
$2.50 / 1M input tokens
$1.25 / 1M input tokens
$1.25 / 1M cached** input tokens
$10.00 / 1M output tokens
$5.00 / 1M output tokens
gpt-4o-audio-preview
Text
$2.50 / 1M input tokens
$10.00 / 1M output tokens
Audio
$40.00 / 1M input tokens
$80.00 / 1M output tokens
gpt-4o-audio-preview-2024-12-17
Text
$2.50 / 1M input tokens
$10.00 / 1M output tokens
Audio
$40.00 / 1M input tokens
$80.00 / 1M output tokens
gpt-4o-audio-preview-2024-10-01
Text
$2.50 / 1M input tokens
$10.00 / 1M output tokens
Audio
$100.00 / 1M input tokens
$200.00 / 1M output tokens
gpt-4o-2024-05-13
$5.00 / 1M input tokens
$2.50 / 1M input tokens
$15.00 / 1M output tokens
$7.50 / 1M output tokens

GPT-4o mini
GPT-4o mini is our most cost-efficient small model that’s smarter and cheaper than GPT-3.5 Turbo, and has vision capabilities.

Learn about GPT-4o mini(opens in a new window)
Model
Pricing
Pricing with Batch API*
gpt-4o-mini
$0.150 / 1M input tokens
$0.075 / 1M input tokens
$0.075 / 1M cached** input tokens
$0.600 / 1M output tokens
$0.300 / 1M output tokens
gpt-4o-mini-2024-07-18
$0.150 / 1M input tokens
$0.075 / 1M input tokens
$0.075 / 1M cached** input tokens
$0.600 / 1M output tokens
$0.300 / 1M output tokens
gpt-4o-mini-audio-preview
Text
$0.150 / 1M input tokens
$0.600 / 1M output tokens
Audio
$10.000 / 1M input tokens
$20.000 / 1M output tokens
gpt-4o-mini-audio-preview-2024-12-17
Text
$0.150 / 1M input tokens
$0.600 / 1M output tokens
Audio
$10.000 / 1M input tokens
$20.000 / 1M output tokens

OpenAI o1
o1 is our frontier reasoning model that supports tools, Structured Outputs, and vision. The model has 200K context and an October 2023 knowledge cutoff.

Learn about o1
Model
Pricing
Pricing with Batch API***
o1
$15.00 / 1M input tokens
$7.50 / 1M input tokens
$7.50 / 1M cached* input tokens
$60.00 / 1M output** tokens
$30.00 / 1M output** tokens
o1-2024-12-17
$15.00 / 1M input tokens
$7.50 / 1M input tokens
$7.50 / 1M cached* input tokens
$60.00 / 1M output** tokens
$30.00 / 1M output** tokens
o1-preview
$15.00 / 1M input tokens
$7.50 / 1M input tokens
$7.50 / 1M cached* input tokens
$60.00 / 1M output** tokens
$30.00 / 1M output** tokens
o1-preview-2024-09-12
$15.00 / 1M input tokens
$7.50 / 1M input tokens
$7.50 / 1M cached* input tokens
$60.00 / 1M tokens
$30.00 / 1M output** tokens

OpenAI o3-mini
o3-mini is our cost-efficient reasoning model that’s optimized for coding, math, and science, and supports tools and Structured Outputs.

Learn about o3-mini >⁠(opens in a new window)

Learn more about o3(opens in a new window)
Model
Pricing
Pricing with Batch API***
o3-mini
$1.10 / 1M input tokens
$0.55 / 1M input tokens
$0.55 / 1M cached* input tokens
$4.40 / 1M output** tokens
$2.20 / 1M output** tokens
03-mini-2025-01-31
$1.10 / 1M input tokens
$0.55 / 1M input tokens
$0.55 / 1M cached* input tokens
$4.40 / 1M output** tokens
$2.20 / 1M output** tokens


o1-mini-2024-09-12
$1.10 / 1M tokens
$4.40 / 1M tokens
$0.55 / 1M cached* tokens
chatgpt-4o-latest
$5.00 / 1M tokens
$15.00 / 1M tokens
gpt-4-turbo
$10.00 / 1M tokens
$30.00 / 1M tokens
gpt-4-turbo-2024-04-09
$10.00 / 1M tokens
$30.00 / 1M tokens
gpt-4
$30.00 / 1M tokens
$60.00 / 1M tokens
gpt-4-32k
$60.00 / 1M tokens
$120.00 / 1M tokens
gpt-4-0125-preview
$10.00 / 1M tokens
$30.00 / 1M tokens
gpt-4-1106-preview
$10.00 / 1M tokens
$30.00 / 1M tokens
gpt-4-vision-preview
$10.00 / 1M tokens
$30.00 / 1M tokens
gpt-3.5-turbo-0125
$0.50 / 1M tokens
$1.50 / 1M tokens
gpt-3.5-turbo-instruct
$1.50 / 1M tokens
$2.00 / 1M tokens
gpt-3.5-turbo-1106
$1.00 / 1M tokens
$2.00 / 1M tokens
gpt-3.5-turbo-0613
$1.50 / 1M tokens
$2.00 / 1M tokens
gpt-3.5-turbo-16k-0613
$3.00 / 1M tokens
$4.00 / 1M tokens
gpt-3.5-turbo-0301
$1.50 / 1M tokens
$2.00 / 1M tokens
davinci-002
$2.00 / 1M tokens
$2.00 / 1M tokens
babbage-002
$0.40 / 1M tokens
$0.40 / 1M tokens
```
These are copied from a table, so in general if it's ambiguous, the first price is the one that I want (i.e. without batching or caching)


Please update this python code to include all the prices above:

```python
GPT_3_5_TURBO_PRICE_PER_TOKEN: Pricing = {
    "prompt": 0.50 / 1_000_000,
    "response": 1.50 / 1_000_000,
}

GPT_3_5_TURBO_16K_PRICE_PER_TOKEN: Pricing = {
    "prompt": 0.003 / 1000,
    "response": 0.004 / 1000,
}

GPT_4_PRICE_PER_TOKEN: Pricing = {
    "prompt": 30.0 / 1_000_000,
    "response": 60.0 / 1_000_000,
}

GPT_4_TURBO_PRICE_PER_TOKEN: Pricing = {
    "prompt": 10.0 / 1_000_000,
    "response": 30.0 / 1_000_000,
}

GPT_4_32K_PRICE_PER_TOKEN: Pricing = {
    "prompt": 60.0 / 1_000_000,
    "response": 120.0 / 1_000_000,
}

GPT_4_O_2024_05_13_PRICE_PER_TOKEN: Pricing = {
    "prompt": 5.0 / 1_000_000,
    "response": 15.0 / 1_000_000,
}

GPT_4_O_2024_08_06_PRICE_PER_TOKEN: Pricing = {
    "prompt": 2.50 / 1_000_000,
    "response": 10.0 / 1_000_000,
}

GPT_4_O_MINI_PRICE_PER_TOKEN: Pricing = {
    "prompt": 0.150 / 1_000_000,
    "response": 0.600 / 1_000_000,
}

O_1_PREVIEW_PRICE_PER_TOKEN: Pricing = {
    "prompt": 15.0 / 1_000_000,
    "response": 60.0 / 1_000_000,
}

O_1_MINI_PRICE_PER_TOKEN: Pricing = {
    "prompt": 3.0 / 1_000_000,
    "response": 12.0 / 1_000_000,
}


def gpt_pricing(model: str) -> Optional[Pricing]:
    if model.startswith("gpt-3.5-turbo-16k"):
        return GPT_3_5_TURBO_16K_PRICE_PER_TOKEN
    elif model.startswith("gpt-3.5-turbo"):
        return GPT_3_5_TURBO_PRICE_PER_TOKEN
    elif model.startswith("gpt-4-32k"):
        return GPT_4_32K_PRICE_PER_TOKEN
    elif model.startswith("gpt-4o-mini"):
        return GPT_4_O_MINI_PRICE_PER_TOKEN
    elif model.startswith("gpt-4o-2024-05-13") or model.startswith("chatgpt-4o-latest"):
        return GPT_4_O_2024_05_13_PRICE_PER_TOKEN
    elif model.startswith("gpt-4o"):
        return GPT_4_O_2024_08_06_PRICE_PER_TOKEN
    elif model.startswith("gpt-4-turbo") or re.match(r"gpt-4-\d\d\d\d-preview", model):
        return GPT_4_TURBO_PRICE_PER_TOKEN
    elif model.startswith("gpt-4"):
        return GPT_4_PRICE_PER_TOKEN
    elif model.startswith("o1-preview"):
        return O_1_PREVIEW_PRICE_PER_TOKEN
    elif model.startswith("o1-mini"):
        return O_1_MINI_PRICE_PER_TOKEN
    else:
        return None
``` 

The new price should supercede the old price. Please give me the full code output (do not abbreviate) so I can copy it in as a new pull request
```

I also then checked that these were all consistent with a large language model which did not find any issues. I checked that LLMs were able to find injected errors from this process
```
