### PR TITLE
Add nix flake, devshell and package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,18 @@ Install latest version from source:
 pip install git+https://github.com/kharvd/gpt-cli.git
 ```
 
-Or install by cloning the repository manually:
+Install by cloning the repository manually:
 
 ```bash
 git clone https://github.com/kharvd/gpt-cli.git
 cd gpt-cli
 pip install .
+```
+
+Or use with `nix`:
+
+```bash
+nix run github:kharvd/gpt-cli
 ```
 
 Add the OpenAI API key to your `.bashrc` file (in the root of your home folder).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Command-line interface for ChatGPT, Claude and Bard";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+
+      python = pkgs.python3.withPackages (ps:
+        with ps; [
+          pydantic
+          anthropic
+          attrs
+          black
+          cohere
+          google-generativeai
+          openai
+          prompt-toolkit
+          pytest
+          pyyaml
+          rich
+          typing-extensions
+        ]);
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = [
+          python
+          pkgs.uv
+        ];
+      };
+      packages = rec {
+        default = gpt-cli;
+        gpt-cli = pkgs.callPackage ./package.nix {};
+      };
+    });
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  python3,
+}:
+python3Packages.buildPythonApplication {
+  pname = "gpt-cli";
+  version = "0.3.2";
+  format = "pyproject";
+
+  preBuild = ''
+    substituteInPlace pyproject.toml \
+      --replace 'anthropic~=0.44.0' 'anthropic' \
+      --replace 'black~=24.10.0' 'black' \
+      --replace 'google-generativeai~=0.8.4' 'google-generativeai' \
+      --replace 'openai~=1.60.0' 'openai' \
+      --replace 'pydantic<2' 'pydantic'
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    pip
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    anthropic
+    attrs
+    black
+    cohere
+    google-generativeai
+    openai
+    prompt-toolkit
+    pytest
+    pyyaml
+    rich
+    typing-extensions
+    pydantic
+  ];
+
+  src = fetchFromGitHub {
+    owner = "kharvd";
+    repo = "gpt-cli";
+    rev = "08b535cb459f2f2269d8889de297f7f995d800f4";
+    sha256 = "sha256-Zmqhdh+XMvJ3bhW+qkQOJT3nf+8luv7aJGW6xJSPuns=";
+  };
+
+  meta = with lib; {
+    description = "Command-line interface for ChatGPT, Claude and Bard";
+    homepage = "https://github.com/kharvd/gpt-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [_404wolf];
+  };
+}


### PR DESCRIPTION
Add a top level `flake.nix` so that nix users can run gpt-cli with "nix run github:kharvd/gpt-cli" (or build/install it with nix) and contributors with nix can have a devshell. 